### PR TITLE
"Multiply assigned" error more user friendly

### DIFF
--- a/ivy/ivy_actions.py
+++ b/ivy/ivy_actions.py
@@ -408,7 +408,7 @@ class AssignAction(Action):
         lhs_vars = used_variables_ast(lhs)
         if any(v not in lhs_vars for v in used_variables_ast(rhs)):
             print self
-            raise IvyError(self,"multiply assigned: {}".format(lhs.rep))
+            raise IvyError(self,"Left hand side of assignments must use all placeholders used on right hand side: {}".format(lhs.rep))
 
         type_check(domain,rhs)
         if is_individual_ast(lhs) != is_individual_ast(rhs):


### PR DESCRIPTION
Hi!

I stumbled upon the error "multiply assigned[...]" trying to write:
`w(self, V) := incomming_message(self, O) & message(O, V);`
where
`relation message(N:node.t, V:value.t)` specifies the values N broadcasts.
`relation incomming_message(A:node.t, B:node.t)` specifies that A sent these values to B. 
I expected that w(self, V) would be set to true for all `O, V` where `O` sent a message to `self` and V is one of the values O is related to via` message`.

I had to dig into ivy_actions.py to understand the meaning of the error and thought I would change the wording to fit the if statement that checks for the error. 

I'm not sure if 'placeholders' is the right word in this context.