### PR TITLE
Fix setup bugs encountered when provisioning in Vagrant

### DIFF
--- a/scripts/setup/python.sh
+++ b/scripts/setup/python.sh
@@ -20,6 +20,8 @@ pip install --user --upgrade $force --editable $gitroot
 # see <https://github.com/pygraphviz/pygraphviz/issues/71> for more information.
 pip install --user --upgrade --force-reinstall pygraphviz --install-option="--include-path=/usr/include/graphviz" --install-option="--library-path=/usr/lib/graphviz/"
 
+# required by ivy_graphviz, which is imported when running the ivy executable
+pip install pydot
 # begin: ipython support (unmaintainted)
 ## `ipython[notebook]` requires a version of pip >= 9.0.1 to function properly
 ## with python 2.7. see <https://github.com/ipython/ipython/blob/master/README.rst>

--- a/scripts/setup/z3.sh
+++ b/scripts/setup/z3.sh
@@ -18,7 +18,7 @@ case $1 in
         echo "# to the environment."
         echo "export PATH=$gitroot/submodules/z3/build:\$PATH"
         echo "export LD_LIBRARY_PATH=$gitroot/submodules/z3/build:\$LD_LIBRARY_PATH"
-        echo "export PYTHONPATH=$gitroot/submodules/z3/build:\$PYTHONPATH"
+        echo "export PYTHONPATH=$gitroot/submodules/z3/build/python:\$PYTHONPATH"
         ;;
     "build")
         # show what's happening.


### PR DESCRIPTION
This PR fixes two bugs that I encountered when provisioning a new Ivy Vagrant machine earlier today:

1. The `scripts/setup/z3.sh` script appended the incorrect Z3 directory to `PYTHONPATH`; it should have been `<z3 build dir>/python` but was just `<z3 build dir>`

2. Running the `ivy` executable ends up importing some UI stuff, which requires the `pydot` Python library. I added a line `scripts/setup/python.sh` that installs the `pydot` package from PIP.